### PR TITLE
remove time dep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,6 @@
     "purescript-prelude": "^3.1.1",
     "purescript-web3": "^0.22.1",
     "purescript-web3-generator": "^0.21.2",
-    "purescript-js-date": "^5.1.0",
     "purescript-console": "^3.0.0",
     "purescript-errors": "^3.0.0",
     "purescript-node-process": "^5.0.0",

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,6 @@
     "purescript-debug": "^3.0.0",
     "purescript-mkdirp": "^0.3.0",
     "purescript-logging": "^2.0.0",
-    "purescript-now": "^3.0.0",
     "purescript-validation": "^3.2.0",
     "purescript-random": "^3.0.0"
   },

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -31,7 +31,6 @@ if this functionality is not required. One may want to store this script in a di
     import Control.Monad.Aff.Console (CONSOLE)
     import Control.Monad.Eff (Eff)
     import Control.Monad.Eff.Exception (EXCEPTION)
-    import Control.Monad.Eff.Now (NOW)
     import Node.FS.Aff (FS)
     import Node.Process (PROCESS)
     import Network.Ethereum.Web3 (ETH)
@@ -42,7 +41,6 @@ if this functionality is not required. One may want to store this script in a di
             , fs :: FS
             , process :: PROCESS
             , exception :: EXCEPTION
-            , now :: NOW
             , eth :: ETH
             | eff
             )

--- a/docs/deployments.rst
+++ b/docs/deployments.rst
@@ -158,13 +158,12 @@ methodically in a separate ``deploy/`` subproject. The latter is demonstrated be
    import Control.Monad.Eff (Eff)
    import Control.Monad.Eff.Console (CONSOLE)
    import Control.Monad.Eff.Exception (EXCEPTION)
-   import Control.Monad.Eff.Now (NOW)
    import Network.Ethereum.Web3 (ETH)
    import Node.FS.Aff (FS)
    import Node.Process (PROCESS)
    import MyDeployScript (deployScript) as MyDeployScript
    
-   main :: forall e. Eff (now :: NOW, console :: CONSOLE, eth :: ETH, fs :: FS, process :: PROCESS, exception :: EXCEPTION | e) Unit
+   main :: forall e. Eff (console :: CONSOLE, eth :: ETH, fs :: FS, process :: PROCESS, exception :: EXCEPTION | e) Unit
    main = deployMain MyDeployScript.deployScript
 
 We can then invoke this script as follows:

--- a/src/Chanterelle.purs
+++ b/src/Chanterelle.purs
@@ -12,7 +12,6 @@ import Chanterelle.Internal.Types.Deploy (DeployM)
 import Control.Monad.Aff.Console (CONSOLE)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (EXCEPTION)
-import Control.Monad.Eff.Now (NOW)
 import Control.Monad.Eff.Unsafe (unsafeCoerceEff)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
@@ -24,7 +23,7 @@ import Node.Yargs.Setup (usage, defaultVersion, defaultHelp, example)
 
 compileMain
   :: forall eff.
-     Eff (console :: CONSOLE, fs :: FS, process :: PROCESS, exception :: EXCEPTION, now :: NOW | eff) Unit
+     Eff (console :: CONSOLE, fs :: FS, process :: PROCESS, exception :: EXCEPTION| eff) Unit
 compileMain =
     let setup = usage "$0 --log-level <level>"
              <> example "$0 --log-level debug" "Run the compile phase with the given log level."

--- a/src/Chanterelle/Compile.purs
+++ b/src/Chanterelle/Compile.purs
@@ -11,7 +11,6 @@ import Control.Monad.Aff.Console (CONSOLE)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Exception (message)
-import Control.Monad.Eff.Now (NOW)
 import Control.Monad.Error.Class (try)
 import Data.Either (Either(..))
 import Node.FS (FS)
@@ -20,7 +19,7 @@ import Node.Process as P
 
 compileProject
   :: forall e.
-     Eff (console :: CONSOLE, fs :: FS, process :: PROCESS, now :: NOW | e) Unit
+     Eff (console :: CONSOLE, fs :: FS, process :: PROCESS | e) Unit
 compileProject = do
     root <- liftEff P.cwd
     void $ launchAff $ do

--- a/src/Chanterelle/Genesis.purs
+++ b/src/Chanterelle/Genesis.purs
@@ -1,4 +1,4 @@
-module Chanterelle.Genesis 
+module Chanterelle.Genesis
     ( runGenesisGenerator
     ) where
 
@@ -13,7 +13,6 @@ import Control.Monad.Aff.Console (CONSOLE)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Exception (message)
-import Control.Monad.Eff.Now (NOW)
 import Control.Monad.Error.Class (try)
 import Data.Argonaut as A
 import Data.Either (Either(..))
@@ -26,7 +25,7 @@ import Node.Process (PROCESS)
 import Node.Process as P
 import Prelude (Unit, bind, show, void, ($), (<<<), (<>), (>>=))
 
-runGenesisGenerator :: forall e. FilePath -> FilePath -> Eff (console :: CONSOLE, fs :: FS, now :: NOW, process :: PROCESS, eth :: ETH | e) Unit 
+runGenesisGenerator :: forall e. FilePath -> FilePath -> Eff (console :: CONSOLE, fs :: FS, process :: PROCESS, eth :: ETH | e) Unit
 runGenesisGenerator genesisIn genesisOut = do
     root <- liftEff P.cwd
     void <<< launchAff $

--- a/src/Chanterelle/Internal/Compile.purs
+++ b/src/Chanterelle/Internal/Compile.purs
@@ -14,7 +14,7 @@ import Chanterelle.Internal.Types.Compile (CompileError(..), OutputContract(..),
 import Chanterelle.Internal.Types.Project (ChanterelleProject(..), ChanterelleProjectSpec(..), ChanterelleModule(..), Dependency(..))
 import Chanterelle.Internal.Utils.FS (assertDirectory, fileIsDirty)
 import Chanterelle.Internal.Utils.Json (jsonStringifyWithSpaces)
-import Chanterelle.Internal.Utils.Time (now)
+import Chanterelle.Internal.Utils.Time (now, toEpoch)
 import Control.Error.Util (hush)
 import Control.Monad.Aff (attempt)
 import Control.Monad.Aff.Class (class MonadAff, liftAff)
@@ -210,7 +210,7 @@ writeBuildArtifact srcName filepath output solContractName = do
   co <- decodeContract srcName output
   co' <- resolveContractMainModule filepath co solContractName
   assertDirectory (Path.dirname filepath)
-  epochTime <- liftEff now
+  epochTime <- toEpoch <$> liftEff now
   log Debug $ "Writing artifact " <> filepath
   liftAff $ FS.writeTextFile UTF8 filepath <<< jsonStringifyWithSpaces 4 $ encodeOutputContract co' epochTime
 

--- a/src/Chanterelle/Internal/Genesis.purs
+++ b/src/Chanterelle/Internal/Genesis.purs
@@ -16,7 +16,6 @@ import Control.Monad.Aff.Console (CONSOLE)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Eff.Exception (message)
-import Control.Monad.Eff.Now (NOW)
 import Control.Monad.Eff.Random (RANDOM, randomRange)
 import Control.Monad.Error.Class (try, throwError)
 import Control.Monad.Except.Trans (ExceptT(..), except, runExceptT, withExceptT)
@@ -102,7 +101,7 @@ generateAddress blacklist = do
         mkHexAddress s = mkHexString s >>= mkAddress
 
 generateGenesis :: forall eff m
-                 . MonadAff (fs :: FS, console :: CONSOLE, now :: NOW, process :: PROCESS, eth :: ETH | eff) m
+                 . MonadAff (fs :: FS, console :: CONSOLE, process :: PROCESS, eth :: ETH | eff) m
                 => ChanterelleProject
                 -> FilePath
                 -> m (Either GenesisGenerationError GenesisBlock)
@@ -177,7 +176,7 @@ generateGenesis cp@(ChanterelleProject project) genesisIn = liftAff <<< runExcep
             genTxt <- wrapLoadFailure (try $ FS.readTextFile UTF8 genesisIn)
             wrapLoadFailure (pure $ A.jsonParser genTxt >>= A.decodeJson)
 
-runGenesisGenerator :: forall e. FilePath -> FilePath -> Eff (console :: CONSOLE, fs :: FS, now :: NOW, process :: PROCESS, eth :: ETH | e) Unit 
+runGenesisGenerator :: forall e. FilePath -> FilePath -> Eff (console :: CONSOLE, fs :: FS, process :: PROCESS, eth :: ETH | e) Unit 
 runGenesisGenerator genesisIn genesisOut = do
     root <- liftEff P.cwd
     void <<< launchAff $

--- a/src/Chanterelle/Internal/Logging.purs
+++ b/src/Chanterelle/Internal/Logging.purs
@@ -16,13 +16,13 @@ import Chanterelle.Internal.Types.Compile as Compile
 import Chanterelle.Internal.Types.Deploy as Deploy
 import Chanterelle.Internal.Types.Genesis as Genesis
 import Chanterelle.Internal.Types.Project (Network(..))
+import Chanterelle.Internal.Utils.Time (now, toISOString)
 import Control.Logger as Logger
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff, class MonadEff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Console as Console
 import Control.Monad.Eff.Unsafe (unsafeCoerceEff)
-import Data.JSDate (now, toISOString)
 import Data.String (toUpper)
 import Data.Traversable (for_)
 import Data.Tuple (Tuple(..))
@@ -72,8 +72,7 @@ fancyColorLogger :: forall eff m a
                  => Loggable a
                  => Logger.Logger m { level :: LogLevel, msg :: a }
 fancyColorLogger = Logger.Logger $ \{ level, msg } -> liftEff <<< unsafeCoerceEff $ do
-    dt <- now
-    iso <- toISOString dt
+    iso <- toISOString <$> now
     Console.log $ colorize level (iso <> " [" <> show level <> "] " <> logify msg)
   where
     colorize level = withGraphics (foreground $ logLevelColor level)

--- a/src/Chanterelle/Internal/Types/Compile.purs
+++ b/src/Chanterelle/Internal/Types/Compile.purs
@@ -9,7 +9,6 @@ import Control.Monad.Aff (Aff, Milliseconds(..))
 import Control.Monad.Aff.Class (class MonadAff)
 import Control.Monad.Aff.Console (CONSOLE)
 import Control.Monad.Eff.Class (class MonadEff)
-import Control.Monad.Eff.Now (NOW)
 import Control.Monad.Error.Class (class MonadThrow)
 import Control.Monad.Except (ExceptT, runExceptT)
 import Control.Monad.Reader (ReaderT, runReaderT)
@@ -37,20 +36,20 @@ data CompileError = CompileParseError    { objectName :: String, parseError :: S
 
 -- | Monad Stack for contract deployment.
 newtype CompileM eff a =
-  CompileM (ReaderT ChanterelleProject (ExceptT CompileError (Aff (fs :: FS, console :: CONSOLE, process :: PROCESS, now :: NOW | eff))) a)
+  CompileM (ReaderT ChanterelleProject (ExceptT CompileError (Aff (fs :: FS, console :: CONSOLE, process :: PROCESS | eff))) a)
 
 runCompileM
   :: forall eff a.
      CompileM eff a
   -> ChanterelleProject
-  -> Aff (fs :: FS, console :: CONSOLE, process :: PROCESS, now :: NOW | eff) (Either CompileError a)
+  -> Aff (fs :: FS, console :: CONSOLE, process :: PROCESS | eff) (Either CompileError a)
 runCompileM (CompileM m) = runExceptT <<< runReaderT m
 
 runCompileMExceptT
   :: forall eff a.
      CompileM eff a
   -> ChanterelleProject
-  -> ExceptT CompileError (Aff (fs :: FS, console :: CONSOLE, process :: PROCESS, now :: NOW | eff)) a
+  -> ExceptT CompileError (Aff (fs :: FS, console :: CONSOLE, process :: PROCESS | eff)) a
 runCompileMExceptT (CompileM m) = runReaderT m
 
 derive newtype instance functorCompileM     :: Functor (CompileM eff)
@@ -60,8 +59,8 @@ derive newtype instance bindCompileM        :: Bind (CompileM eff)
 derive newtype instance monadCompileM       :: Monad (CompileM eff)
 derive newtype instance monadThrowCompileM  :: MonadThrow CompileError (CompileM eff)
 derive newtype instance monadAskCompileM    :: MonadAsk ChanterelleProject (CompileM eff)
-derive newtype instance monadEffCompileM    :: MonadEff (fs :: FS, console :: CONSOLE, process :: PROCESS, now :: NOW | eff) (CompileM eff)
-derive newtype instance monadAffCompileM    :: MonadAff (fs :: FS, console :: CONSOLE, process :: PROCESS, now :: NOW | eff) (CompileM eff)
+derive newtype instance monadEffCompileM    :: MonadEff (fs :: FS, console :: CONSOLE, process :: PROCESS | eff) (CompileM eff)
+derive newtype instance monadAffCompileM    :: MonadAff (fs :: FS, console :: CONSOLE, process :: PROCESS | eff) (CompileM eff)
 
 --------------------------------------------------------------------------------
 -- | Solc Types and Codecs

--- a/src/Chanterelle/Internal/Utils/Time.js
+++ b/src/Chanterelle/Internal/Utils/Time.js
@@ -1,0 +1,5 @@
+"use strict";
+
+exports.now = function () {
+  return new Date().getTime();
+};

--- a/src/Chanterelle/Internal/Utils/Time.js
+++ b/src/Chanterelle/Internal/Utils/Time.js
@@ -1,5 +1,13 @@
 "use strict";
 
 exports.now = function () {
-  return new Date().getTime();
+    return new Date();
+};
+
+exports.toEpoch = function (time) {
+    return time.getTime();
+};
+
+exports.toISOString = function (time) {
+    return time.toISOString();
 };

--- a/src/Chanterelle/Internal/Utils/Time.purs
+++ b/src/Chanterelle/Internal/Utils/Time.purs
@@ -3,4 +3,12 @@ module Chanterelle.Internal.Utils.Time where
 import Control.Monad.Eff (Eff)
 import Data.Time.Duration (Milliseconds)
 
-foreign import now :: forall eff. Eff eff Milliseconds
+foreign import data Time :: Type
+
+foreign import now :: forall eff. Eff eff Time
+
+foreign import toEpoch :: Time -> Milliseconds
+
+foreign import toISOString :: Time -> String
+
+

--- a/src/Chanterelle/Internal/Utils/Time.purs
+++ b/src/Chanterelle/Internal/Utils/Time.purs
@@ -1,0 +1,6 @@
+module Chanterelle.Internal.Utils.Time where
+
+import Control.Monad.Eff (Eff)
+import Data.Time.Duration (Milliseconds)
+
+foreign import now :: forall eff. Eff eff Milliseconds


### PR DESCRIPTION
We were get a lot of dependency problems in other libs because of datetime, js-date-time version problems. We were doing something so simple we should just remove the dep and implement the functionality as a util