### PR TITLE
Extra abis

### DIFF
--- a/src/Chanterelle/Internal/Codegen.purs
+++ b/src/Chanterelle/Internal/Codegen.purs
@@ -17,14 +17,14 @@ import Data.Argonaut (decodeJson)
 import Data.Argonaut.Parser (jsonParser)
 import Data.Argonaut.Prisms (_Object)
 import Data.Array (mapMaybe)
-import Data.CodeGen (GeneratorOptions, runImported) as PSWeb3Gen
+import Data.CodeGen (GeneratorOptions, ABIError(..), runImported, generatePS) as PSWeb3Gen
 import Data.Either (Either(..), either)
 import Data.Generator (genCode) as PSWeb3Gen
 import Data.Identity (Identity(..))
 import Data.Lens ((^?))
 import Data.Lens.Index (ix)
 import Data.Maybe (Maybe(..))
-import Data.Traversable (for)
+import Data.Traversable (for, for_)
 import Node.Encoding (Encoding(UTF8))
 import Node.FS.Aff as FS
 import Node.Path (FilePath)
@@ -49,6 +49,17 @@ generatePS p@(ChanterelleProject project) = do
       assertDirectory (Path.dirname mod.pursPath)
       log Info $ "writing PureScript bindings for " <> mod.moduleName
       liftAff $ FS.writeTextFile UTF8 mod.pursPath psModule
+  -- generate all the modules from the extra-abis path
+  let mextraJsonDir = case project.spec of
+        ChanterelleProjectSpec s -> s.extraAbis
+  liftAff $ case mextraJsonDir of
+    Nothing -> pure unit
+    Just extraJsonDir -> do
+      errs <- PSWeb3Gen.generatePS (psArgs {jsonDir = extraJsonDir})
+      for_ errs \(PSWeb3Gen.ABIError err) ->
+        log Error $ "while parsing abi type of object at index: "
+          <> show err.idx <> " from: " <> err.abiPath <> " got error: " <> err.error
+
 
 projectPSArgs
   :: ChanterelleProject

--- a/src/Chanterelle/Internal/Codegen.purs
+++ b/src/Chanterelle/Internal/Codegen.purs
@@ -55,6 +55,7 @@ generatePS p@(ChanterelleProject project) = do
   liftAff $ case mextraJsonDir of
     Nothing -> pure unit
     Just extraJsonDir -> do
+      log Info $ "Writing additional abis from directory " <> extraJsonDir
       errs <- PSWeb3Gen.generatePS (psArgs { jsonDir = extraJsonDir
                                            , truffle = false
                                            }

--- a/src/Chanterelle/Internal/Codegen.purs
+++ b/src/Chanterelle/Internal/Codegen.purs
@@ -55,7 +55,7 @@ generatePS p@(ChanterelleProject project) = do
   liftAff $ case mextraJsonDir of
     Nothing -> pure unit
     Just extraJsonDir -> do
-      log Info $ "Writing additional abis from directory " <> extraJsonDir
+      log Info $ "Writing additional PureScript bindings using abis from directory " <> extraJsonDir
       errs <- PSWeb3Gen.generatePS (psArgs { jsonDir = extraJsonDir
                                            , truffle = false
                                            }

--- a/src/Chanterelle/Internal/Codegen.purs
+++ b/src/Chanterelle/Internal/Codegen.purs
@@ -55,7 +55,10 @@ generatePS p@(ChanterelleProject project) = do
   liftAff $ case mextraJsonDir of
     Nothing -> pure unit
     Just extraJsonDir -> do
-      errs <- PSWeb3Gen.generatePS (psArgs {jsonDir = extraJsonDir})
+      errs <- PSWeb3Gen.generatePS (psArgs { jsonDir = extraJsonDir
+                                           , truffle = false
+                                           }
+                                   )
       for_ errs \(PSWeb3Gen.ABIError err) ->
         log Error $ "while parsing abi type of object at index: "
           <> show err.idx <> " from: " <> err.abiPath <> " got error: " <> err.error

--- a/src/Chanterelle/Internal/Types/Project.purs
+++ b/src/Chanterelle/Internal/Types/Project.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Chanterelle.Internal.Utils.Json (decodeJsonAddress, decodeJsonHexString, encodeJsonAddress, encodeJsonHexString, gfWithDecoder)
 import Control.Alt ((<|>))
-import Data.Argonaut (class EncodeJson, class DecodeJson, Json, encodeJson, decodeJson, (:=), (~>), (.?), (.??), jsonEmptyObject)
+import Data.Argonaut (class EncodeJson, class DecodeJson, encodeJson, decodeJson, (:=), (~>), (.?), (.??), jsonEmptyObject)
 import Data.Array (elem, filter, null)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe, fromMaybe)

--- a/src/Chanterelle/Internal/Types/Project.purs
+++ b/src/Chanterelle/Internal/Types/Project.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Chanterelle.Internal.Utils.Json (decodeJsonAddress, decodeJsonHexString, encodeJsonAddress, encodeJsonHexString, gfWithDecoder)
 import Control.Alt ((<|>))
-import Data.Argonaut (class EncodeJson, class DecodeJson, encodeJson, decodeJson, (:=), (~>), (.?), (.??), jsonEmptyObject)
+import Data.Argonaut (class EncodeJson, class DecodeJson, Json, encodeJson, decodeJson, (:=), (~>), (.?), (.??), jsonEmptyObject)
 import Data.Array (elem, filter, null)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe, fromMaybe)
@@ -47,7 +47,7 @@ instance encodeJsonInjectableLibraryCode :: EncodeJson InjectableLibraryCode whe
 instance decodeJsonInjectableLibraryCode :: DecodeJson InjectableLibraryCode where
   decodeJson d = decodeSourceCode <|> decodeBytecode <|> Left "not a valid InjectableLibrarySource"
       where decodeSourceCode = decodeJson d >>= (\o -> InjectableWithSourceCode <$> o .?? "root" <*> o .? "file")
-            decodeBytecode   = do 
+            decodeBytecode   = do
               o <- decodeJson d
               bc <- gfWithDecoder decodeJsonHexString o "bytecode"
               pure $ InjectableWithBytecode bc
@@ -217,6 +217,7 @@ newtype ChanterelleProjectSpec =
                          , artifactsDir        :: FilePath
                          , modules             :: Array String
                          , dependencies        :: Array Dependency
+                         , extraAbis           :: Maybe FilePath
                          , libraries           :: Libraries
                          , networks            :: Networks
                          , solcOutputSelection :: Array String
@@ -236,6 +237,7 @@ instance encodeJsonChanterelleProjectSpec :: EncodeJson ChanterelleProjectSpec w
       ~> "artifacts-dir"         := encodeJson project.artifactsDir
       ~> "modules"               := encodeJson project.modules
       ~> "dependencies"          := encodeJson project.dependencies
+      ~> "extra-abis"            := encodeJson project.dependencies
       ~> "libraries"             := encodeJson project.libraries
       ~> "networks"              := encodeJson project.networks
       ~> "solc-output-selection" := encodeJson project.solcOutputSelection
@@ -256,6 +258,7 @@ instance decodeJsonChanterelleProjectSpec :: DecodeJson ChanterelleProjectSpec w
     artifactsDir        <- fromMaybe "build" <$> obj .?? "artifacts-dir"
     modules             <- obj .? "modules"
     dependencies        <- fromMaybe mempty <$> obj .?? "dependencies"
+    extraAbis           <- obj .?? "extra-abis"
     libraries           <- fromMaybe mempty <$> obj .?? "libraries"
     networks            <- fromMaybe mempty <$> obj .?? "networks"
     solcOutputSelection <- fromMaybe mempty <$> obj .?? "solc-output-selection"
@@ -264,7 +267,7 @@ instance decodeJsonChanterelleProjectSpec :: DecodeJson ChanterelleProjectSpec w
     psGenExprPrefix     <- fromMaybe "" <$> psGenObj .?? "expression-prefix"
     psGenModulePrefix   <- fromMaybe "" <$> psGenObj .?? "module-prefix"
     let psGen = { exprPrefix: psGenExprPrefix, modulePrefix: psGenModulePrefix, outputPath: psGenOutputPath }
-    pure $ ChanterelleProjectSpec { name, version, sourceDir, artifactsDir, modules, dependencies, libraries, networks, solcOutputSelection, psGen }
+    pure $ ChanterelleProjectSpec { name, version, sourceDir, artifactsDir, modules, dependencies, extraAbis, libraries, networks, solcOutputSelection, psGen }
 
 data ChanterelleProject =
      ChanterelleProject { root     :: FilePath -- ^ parent directory containing chanterelle.json


### PR DESCRIPTION
add an `extra-abis` field to include .a directory of abis (.json files) that do not come from compiled solidity code that is in this project. This is useful if you don't want to run the generator as a script, which we are moving away from in general.