### PR TITLE
Add error message for improper deploy script naming

### DIFF
--- a/src/ChanterelleMain.js
+++ b/src/ChanterelleMain.js
@@ -6,7 +6,7 @@ exports.loadDeployMFromScriptPath = function (filePath) {
     var scriptPath = path.isAbsolute(filePath) ? filePath : path.join (process.cwd(), filePath);
     var script = require(scriptPath).deploy
     if (script == undefined) {
-      throw "Deploy script is invalid: " + scriptPath
+      throw "Deploy script is invalid or module does not export a \"deploy\" function: " + scriptPath
     }
     return script;
   };

--- a/src/ChanterelleMain.purs
+++ b/src/ChanterelleMain.purs
@@ -105,7 +105,7 @@ main = launchAff_ do
     pure $ DeployOptions {nodeURL, timeout, script: SelectPS script}
   case res of
     Left err -> do
-      log Error $ "Couldn't load deploy script" <> show err
+      log Error $ "Couldn't load deploy script. " <> show err
     Right args' -> chanterelle args'
 
 foreign import loadDeployMFromScriptPath :: String -> Effect (DeployM Unit)


### PR DESCRIPTION
Closes #104.

The main `deploy` script should be named `deploy`.