### PR TITLE
build chanterelle on install and fall back to a system-wide install

### DIFF
--- a/chanterelle-bin.sh
+++ b/chanterelle-bin.sh
@@ -32,9 +32,9 @@ postinstall() {
     cd "$CHNTRL_DIR"
     if [ "$EUID" == "0" ]
     then
-        npm install && bower install --allow-root --config.interactive=false && npm run build
+        npm install && npm run postinstall-bower-root && npm run build
     else
-        npm install && bower install --config.interactive=false && npm run build
+        npm install && npm run postinstall-bower-non-root && npm run build
     fi
 
     if ! global_install_available

--- a/chanterelle-bin.sh
+++ b/chanterelle-bin.sh
@@ -1,17 +1,26 @@
 #!/bin/bash
 
+# Borrowed with love from https://stackoverflow.com/a/246128/1763937
+get_script_dir() {
+  SOURCE="${BASH_SOURCE[0]}"
+  while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  done
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  echo "$DIR"
+}
 
-if [ ! -d './output' ] 
-then 
-    echo "No './output' directory, make sure to compile purescript project."
-    exit 1
-fi
-
+CHNTRL_DIR=$(get_script_dir)
+CHNTRL_OUTPUT_DIR="$CHNTRL_DIR/output";
 
 if [ ! -f './output/ChanterelleMain/index.js' ] 
 then 
-    echo "Make sure you have purescript-chantrelle in your purescript dependencies and it is compiled."
-    exit 1
+    echo "Did not detect a project-level Chanterelle version, will fall back to the system-wide installation." >&2
+    echo "Make sure you have purescript-chantrelle in your PureScript dependencies and it is compiled." >&2
+    node -e "require('$CHNTRL_OUTPUT_DIR/ChanterelleMain/index.js').main();" -- "chanterelle" $*
+else
+    node -e "require('./output/ChanterelleMain/index.js').main();" -- "chanterelle" $*
 fi
 
-node -e "require('./output/ChanterelleMain/index.js').main();" -- "chanterelle" $*

--- a/chanterelle-bin.sh
+++ b/chanterelle-bin.sh
@@ -32,9 +32,9 @@ postinstall() {
     cd "$CHNTRL_DIR"
     if [ "$EUID" == "0" ]
     then
-        bower install --allow-root --config.interactive=false && npm run build
+        npm install && bower install --allow-root --config.interactive=false && npm run build
     else
-        bower install --config.interactive=false && npm run build
+        npm install && bower install --config.interactive=false && npm run build
     fi
 
     if ! global_install_available

--- a/chanterelle-bin.sh
+++ b/chanterelle-bin.sh
@@ -28,29 +28,29 @@ global_install_available() {
     [ -f "$CHNTRL_GLOBAL_MAIN" ]
 }
 
-postinstall() {
+global_postinstall() {
     cd "$CHNTRL_DIR"
     if [ "$EUID" == "0" ]
     then
-        npm install && npm run postinstall-bower-root && npm run build
+        npm install && npm run global-postinstall-bower-root && npm run build
     else
-        npm install && npm run postinstall-bower-non-root && npm run build
+        npm install && npm run global-postinstall-bower-non-root && npm run build
     fi
 
     if ! global_install_available
     then
-      echo '`chanterelle postinstall` did not complete successfully, see output above, correct the issue, and try again'
+      echo '`chanterelle global-postinstall` did not complete successfully, see output above, correct the issue, and try again'
       exit 1
     fi
 }
 
-if [ "$1" == "postinstall" ]
+if [ "$1" == "global-postinstall" ]
 then
     if global_install_available && [ "$2" != "--force" ]
     then
-      echo 'chanterelle postinstall appears to have already completed successfully. Rerun with --force if you want to run it again anyway'
+      echo 'chanterelle global-postinstall appears to have already completed successfully. Rerun with --force if you want to run it again anyway'
     else
-      postinstall
+      global_postinstall
     fi
 else
     if [ -f "$CHNTRL_LOCAL_MAIN" ]
@@ -61,8 +61,8 @@ else
         echo "Make sure you have purescript-chantrelle in your PureScript dependencies and it is compiled." >&2
         if ! global_install_available
         then
-          echo 'A global installation of chanterelle is not available, likely because `chanterelle postinstall` was never run or did not complete successfully' >&2
-          echo 'Please run `chanterelle postinstall` and try again' >&2
+          echo 'A global installation of chanterelle is not available, likely because `chanterelle global-postinstall` was never run or did not complete successfully' >&2
+          echo 'Please run `chanterelle global-postinstall` and try again' >&2
           exit 1
         else
           run_chanterelle "$CHNTRL_GLOBAL_MAIN" $@

--- a/chanterelle-bin.sh
+++ b/chanterelle-bin.sh
@@ -65,6 +65,7 @@ else
           echo 'Please run `chanterelle global-postinstall` and try again' >&2
           exit 1
         else
+          export CHNTRL_IS_GLOBAL=yes
           run_chanterelle "$CHNTRL_GLOBAL_MAIN" $@
         fi
     fi

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,28 +1,79 @@
 .. _installation:
 
-
 =========
-installing Chanterelle CLI
+Installation
 =========
 
-you can install `master` of chanterelle CLI globally using npm:
+Chanterelle exists as both a library and an command-line executable. The library enables
+your applications to take advatange of Chanterelle's rapid development pipeline, while the
+command-line executable provides easy access to Chanterelle's core functionality.
+
+Installing Globally
+------------------
+
+Installing the Chanterelle command-line interface globally allows you to easily access 
+Chanterelle's compilation and code generation interface to prevent cyclical dependency
+problems when bootstrapping a development environment.
+
+The command-line application first attempts to use a project-local version of Chanterelle
+when invoking commands, but has the ability to fall back to a "global" instance, which is
+necessary when a project is first created. Chanterelle tries to use a local installation
+first to prevent incompatibilities that may occur if there is a mismatch between the global
+version and the project-local version.
+
+In order for Chanterelle to be able to fall back to a global installation, one must be
+compiled after installing Chanterelle via NPM. This is done via the ``chanterelle global-postinstall`` 
+subcommand. 
+
+You can install the HEAD of `master` globally by running:
 
 .. code-block:: shell
 
-    npm install -g f-o-a-m/chanterelle
+    npm install -g f-o-a-m/chanterelle  # Install bleeding-edge Chanterelle CLI
+    chanterelle global-postinstall      # Bootstrap the global installation
 
-Or if you would like to install specific version like `v9.9.9 for example do:
-
-.. code-block:: shell
-
-    npm install -g f-o-a-m/chanterelle#v9.9.9
-
-you can also install it locally for particular project too:
-
+Or if you would like to install a specific version, you may specify it via NPM:
 
 .. code-block:: shell
 
-    npm install f-o-a-m/chanterelle
+    npm install -g f-o-a-m/chanterelle#v3.0.0 # Install Chanterelle CLI v3.0.0
+    chanterelle global-postinstall            # Bootstrap the global installation
+
+Installing Locally (per-project)
+------------------
+
+You will likely also want to install Chanterelle local to particular project:
+
+.. code-block:: shell
+
+    npm install --save f-o-a-m/chanterelle      # Add the Chanterelle CLI to NPM path for NPM package scripts
+    bower install --save purescript-chanterelle # Add Chanterelle as a dependency for deployment scripts
+
+If the Chanterelle CLI is invoked within a project containing a local installation that has been compiled,
+it will use the version within that project as opposed to the global one.
 
 
-NOTE: The projects where CLI is used, must also have chanterelle in it's purescript dependencies and whole purescript project should be compiled already.
+What is this cyclic dependency stuff all about?
+------------------
+
+Chanterelle always first attempts to use the version installed within your project. When you've written a deployment script,
+your PureScript compiler will automatically compile the necessary components of Chanterelle to enable it to run as a CLI command
+independent of a global installation. This is an important step, as it prevents version mismatches from affecting the integrity of
+your deployment scripts. To this end, the Chanterelle CLI command always attempts to first use your project-local copy of Chanterelle,
+However, your project needs to compile successfully before that is available. Your deployment script will likely fail to compile as 
+it would depend on PureScript bindings to the smart contracts which are being deployed -- bindings which Chanterelle generates -- and
+if Chanterelle can't compile because your project can't compile -- then you'd be stuck in an endless cyclic dependency. To resolve this,
+Chanterelle allows you to compile an independent global version to fall back to, which would allow you to compile your contracts and
+generate any PureScript necessary to proceed with compilation.
+
+Fair enough, but why do I need to run this ``global-postinstall`` subcommand?
+------------------
+
+Great question! Chanterelle itself is written in PureScript, and as such it depends on the PureScript compiler. The ``global-postinstall`` merely
+compiles the Chanterelle codebase, as it would if you had a project-local version. This is not done as a package postinstall script as, very often in 
+global package setups, NPM might not give sufficient permissions to install the PureScript compiler package that Chanterelle depends on or otherwise 
+install dependencies (for instance, Bower won't be able to read certain configuration files to pull in Chanterelle's PureScript dependencies). To
+maximize the flexibilty of the global installation feature, and avoid running into user-specific permissions Chanterelle separates out this step
+such that it is independent of being installed via NPM.
+
+To avoid running into a myriad of permissions issues, we recommend using `NVM <https://github.com/nvm-sh/nvm>` for managing globally available NPM packages.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "docs": "cd docs; make html;",
     "postinstall": "echo 'If you are installing chanterelle to use globally, you likely want to run `chanterelle postinstall`.'"
   },
-  "devDependencies": {
+  "dependencies": {
     "purescript": "^0.12.0",
     "pulp": "^12.2.0",
     "purescript-psa": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A more functional truffle",
   "license": "ISC",
   "scripts": {
-    "postinstall-bower-root": "bower install --allow-root --config.interactive=false",
-    "postinstall-bower-non-root": "bower install --config.interactive=false",
+    "global-postinstall-bower-root": "bower install --allow-root --config.interactive=false",
+    "global-postinstall-bower-non-root": "bower install --config.interactive=false",
     "build": "pulp build",
     "docs": "cd docs; make html;",
     "postinstall": "echo 'If you are installing chanterelle to use globally, you likely want to run `chanterelle postinstall`.'"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "pulp build",
     "docs": "cd docs; make html;",
-    "postinstall": "HOME=`mktemp -d` bower install --allow-root && npm run build"
+    "postinstall": "echo 'If you are installing chanterelle to use globally, you likely want to run `chanterelle postinstall`.'"
   },
   "devDependencies": {
     "purescript": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "ISC",
   "scripts": {
     "build": "pulp build",
-    "docs": "cd docs; make html;"
+    "docs": "cd docs; make html;",
+    "postinstall": "bower install && npm run build"
   },
   "devDependencies": {
     "purescript": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chanterelle",
-  "version": "2.0.2",
+  "version": "3.1.0",
   "description": "A more functional truffle",
   "license": "ISC",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "A more functional truffle",
   "license": "ISC",
   "scripts": {
+    "postinstall-bower-root": "bower install --allow-root --config.interactive=false",
+    "postinstall-bower-non-root": "bower install --config.interactive=false",
     "build": "pulp build",
     "docs": "cd docs; make html;",
     "postinstall": "echo 'If you are installing chanterelle to use globally, you likely want to run `chanterelle postinstall`.'"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "pulp build",
     "docs": "cd docs; make html;",
-    "postinstall": "bower install && npm run build"
+    "postinstall": "HOME=`mktemp -d` bower install --allow-root && npm run build"
   },
   "devDependencies": {
     "purescript": "^0.12.0",

--- a/src/Chanterelle.purs
+++ b/src/Chanterelle.purs
@@ -50,6 +50,7 @@ data Command s
   | Codegen
   | Genesis GenesisOptions
   | Deploy (DeployOptions s)
+  | GlobalDeploy (DeployOptions s)
 derive instance genericCommand :: Generic (Command s) _
 instance showCommand :: Show (DeployOptions s) => Show (Command s) where show = genericShow
 
@@ -60,6 +61,7 @@ traverseDeployOptions f (Args' o cmd) = Args' o <$> case cmd of
   Codegen -> pure Codegen
   Genesis opts -> pure $ Genesis opts
   Deploy dopts -> Deploy <$> f dopts
+  GlobalDeploy dopts -> GlobalDeploy <$> f dopts
 
 data GenesisOptions = GenesisOptions
   { input :: String
@@ -97,9 +99,13 @@ runCommand project = case _ of
     Codegen -> doCodegen
     Genesis opts -> doGenesis opts
     Deploy opts -> doDeploy opts
+    GlobalDeploy _ -> doGlobalDeploy
   where
     doDeploy (DeployOptions {nodeURL, timeout, script: SelectPS s}) = do
       deploy nodeURL timeout s
+    doGlobalDeploy = do
+      log Error $ "deploy is unavailable as Chanterelle is running from a global installation"
+      log Error $ "Please ensure your project's Chanterelle instance has compiled"
     doClassicBuild = doCompile *> doCodegen
     doCompile = runCompileM Chanterelle.compile project >>= case _ of
       Left err -> logCompileError err

--- a/src/ChanterelleMain.js
+++ b/src/ChanterelleMain.js
@@ -13,3 +13,5 @@ exports.loadDeployMFromScriptPath = function (filePath) {
 };
 
 exports.version_ = require("../../package.json").version
+
+exports.is_global_ = process.env['CHNTRL_IS_GLOBAL'] === 'yes'

--- a/src/ChanterelleMain.purs
+++ b/src/ChanterelleMain.purs
@@ -18,30 +18,38 @@ import Options.Applicative (Parser, ParserInfo, argument, command, customExecPar
 import Text.PrettyPrint.Leijen (indent, text, (</>))
 
 foreign import version_ :: String
+foreign import is_global_ :: Boolean
+
 version :: forall a. Parser (a -> a)
 version = infoOption version_
   (  long "version"
   <> help "Print version information" )
 
-parser :: DirPath -> Parser ArgsCLI
-parser cwd' = ado
+parser :: Boolean -> DirPath -> Parser ArgsCLI
+parser isGlobal cwd' = ado
   opts <- commonOpts cwd'
   cmds <- hsubparser
             ( command "build"
               (info (pure Build)
-                    (progDesc "Build project"))
+                    (progDesc "Build project (compile and codegen)"))
            <> command "compile"
               (info (pure Compile)
                     (progDesc "Compile project"))
            <> command "codegen"
               (info (pure Codegen)
-                    (progDesc "generate purescript"))
+                    (progDesc "Generate PureScript"))
            <> command "genesis"
               (info (Genesis <$> genesisParser)
-                    (progDesc "generate purescript"))
-           <> command "deploy"
-              (info (Deploy <$> deployParser)
-                    (progDesc "run deploy script")) )
+                    (progDesc "Generate a genesis block with libraries"))
+           <> ( if isGlobal
+                then command "deploy"
+                       (info (GlobalDeploy <$> deployParser)
+                        (progDesc "Run a deploy script -- disabled as chanterelle is running from a global installation"))
+                else command "deploy"
+                       (info (Deploy <$> deployParser)
+                        (progDesc "Run a deploy script"))
+             )
+           )
   in Args' opts cmds
 
 genesisParser :: Parser GenesisOptions
@@ -93,15 +101,17 @@ commonOpts cwd' = map CommonOpts $ {optVerbosity:_, rootPath:_}
 
 
 pinfo :: DirPath -> ParserInfo ArgsCLI
-pinfo cwd' = info (parser cwd' <**> (lift2 (>>>) version helper))
-  ( progDesc "A more functional truffle" )
+pinfo cwd' = info ((parser is_global_ cwd') <**> (lift2 (>>>) version helper))
+  ( progDesc $ "A more functional truffle" <> (if is_global_ then " !! USING GLOBAL INSTALL -- `deploy` NOT AVAILABLE !!" else mempty) )
 
 main :: Effect Unit
 main = launchAff_ do
   ourCwd <- liftEffect $ cwd
   args <- liftEffect $ customExecParser (prefs showHelpOnEmpty) (pinfo ourCwd)
   res <- runExceptT $ flip traverseDeployOptions args \(DeployOptions {nodeURL, timeout, script: SelectCLI scriptPath}) -> do
-    script <- ExceptT $ try (liftEffect $ loadDeployMFromScriptPath scriptPath)
+    script <- if is_global_
+              then pure (pure unit)
+              else ExceptT $ try (liftEffect $ loadDeployMFromScriptPath scriptPath)
     pure $ DeployOptions {nodeURL, timeout, script: SelectPS script}
   case res of
     Left err -> do


### PR DESCRIPTION
Currently, a ChanterelleMain has to be compiled within your project's PureScript output directly for the `chanterelle` command to work. This can lead to chicken-and-egg situations where your only dependency on Chanterelle is for deployments, which require you to `chanterelle codegen` to get the PureScript bindings for your Solidity contracts, but you can't use the `chanterelle compile/codegen` commands to do anything because if the rest of your project can't compile, `ChanterelleMain` can't get compiled either. 

This PR modifies `package.json` to notify the user to run `chanterelle postinstall` if they want to be able to use a fallback "global" install. Note that this can't be automated as a package.json `postinstall` script as it may fail in cases where `npm` is running as root or the user doesn't have pulp/bower/etc. globally available. As `sudo npm install` is considered a Very Bad Practice™ anyway, we don't attempt to support that mode any more than is feasible. NVM is a recommended way to manage global package sets for those kinds of use-cases anyway. (For instance, you can't `sudo npm install -g purescript` because `postinstall`s run as `nobody` and the `purescript` postinstaller can't download the `purs` binary, and we need `purescript` to build).

If a project-local ChanterelleMain is available, the old behavior is resumed. If not, the user is notified that we are attempting to fall back to a global install. If a global install is not available, the user is prompted to run `chanterelle global-postinstall` to set up a global installation. `chanterelle global-postinstall` is idempotent (but exits with nonzero in case there's nothing to do and `--force` isn't specified) and can be put into build scripts. Running `global-postinstall` with a global installation already set up should be near instant, as it merely checks that `ChanterelleMain` was built in the same directory as the real `chanterelle-bin.sh`

In principle, these changes should also allow users who want to do stuff like `npm run <some-script-that-calls-chanterelle>` and have it use their project's `node_modules/chanterelle`. they'd likely have to `chanterelle global-postinstall || true && chanterelle whatever-they-want-to-do` in their package.json scripts. small price to pay for bulletproof builds imo.