### PR TITLE
bump dependencies and version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "purescript-prelude": "^4.0.0",
     "purescript-web3": "^2.0.0",
-    "purescript-web3-generator": "^2.0.0",
-    "purescript-solc": "^1.0.0",
+    "purescript-web3-generator": "^2.1.0",
+    "purescript-solc": "^1.1.0",
     "purescript-console": "^4.0.0",
     "purescript-node-process": "^7.0.0",
     "purescript-optparse": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chanterelle",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A more functional truffle",
   "license": "ISC",
   "scripts": {


### PR DESCRIPTION
Bump `purescript-solc` and `purescript-web3-generator` which now support new Solc features and input requirements. Then bump own version