### PR TITLE
Depend on solc 0.6 by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chanterelle",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A more functional truffle",
   "license": "ISC",
   "scripts": {
@@ -19,7 +19,7 @@
     "keccak": "^1.0.2",
     "secp256k1": "^3.0.1",
     "rlp": "^2.0.0",
-    "solc": "^0.5",
+    "solc": "^0.6",
     "spago": "^0.16.0"
   },
   "bin": {


### PR DESCRIPTION
After all the blood sweat and tears (jk) to support solc-0.6, we never actually made the NPM package depend on solc 0.6