### PR TITLE
Sync FS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chanterelle",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "A more functional truffle",
   "license": "ISC",
   "scripts": {

--- a/packages.dhall
+++ b/packages.dhall
@@ -89,7 +89,7 @@ let additions =
         , version =
             "v1.0.0"
         }
-      , solc = 
+      , solc =
         { dependencies =
           [ "aff"
           , "argonaut"

--- a/src/Chanterelle/Internal/Utils/FS.purs
+++ b/src/Chanterelle/Internal/Utils/FS.purs
@@ -13,11 +13,12 @@ import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (liftEffect)
 import Node.Encoding (Encoding(UTF8))
 import Node.FS.Aff as FS
+import Node.FS.Sync as FSSync
 import Node.FS.Stats as Stats
 import Node.Path (FilePath)
 import Node.Path as Path
 
-unparsePath 
+unparsePath
   :: forall p
    . { dir  :: String
      , name :: String
@@ -79,7 +80,7 @@ readTextFile
   => MonadThrow String m
   => FilePath
   -> m String
-readTextFile filename = catchingAff (FS.readTextFile UTF8 filename)
+readTextFile filename = catchingAff (liftEffect $ FSSync.readTextFile UTF8 filename)
 
 writeTextFile
   :: forall m

--- a/src/Chanterelle/Internal/Utils/FS.purs
+++ b/src/Chanterelle/Internal/Utils/FS.purs
@@ -89,7 +89,7 @@ writeTextFile
   => FilePath
   -> String
   -> m Unit
-writeTextFile filename contents = catchingAff (FS.writeTextFile UTF8 filename contents)
+writeTextFile filename contents = catchingAff (liftEffect $ FSSync.writeTextFile UTF8 filename contents)
 
 withTextFile
   :: forall m

--- a/src/Chanterelle/Internal/Utils/FS.purs
+++ b/src/Chanterelle/Internal/Utils/FS.purs
@@ -8,6 +8,7 @@ import Chanterelle.Internal.Utils.Error (catchingAff, withExceptT')
 import Control.Monad.Error.Class (class MonadThrow, throwError)
 import Data.DateTime.Instant (fromDateTime, unInstant)
 import Data.Function.Uncurried (runFn2, runFn3)
+import Data.Int.Bits ((.|.))
 import Effect (Effect)
 import Effect.Aff (Milliseconds)
 import Effect.Aff.Class (class MonadAff, liftAff)
@@ -94,7 +95,12 @@ writeTextFile
   -> m Unit
 writeTextFile filename contents = catchingAff wrapInternalWrite
   where wrapInternalWrite = liftEffect <<< FSInternal.mkEffect $ \_ -> runFn3
-          FSInternal.unsafeRequireFS.writeFileSync filename contents { encoding: show UTF8, flag: "rs+" }
+          FSInternal.unsafeRequireFS.writeFileSync filename contents { encoding: show UTF8, flag: writeSyncFlag }
+
+        writeSyncFlag =     FSInternal.unsafeRequireFS."O_TRUNC"
+                        .|. FSInternal.unsafeRequireFS."O_CREAT"
+                        .|. FSInternal.unsafeRequireFS."O_RDWR"
+                        .|. FSInternal.unsafeRequireFS."O_SYNC"
 
 withTextFile
   :: forall m

--- a/src/Chanterelle/Internal/Utils/FS.purs
+++ b/src/Chanterelle/Internal/Utils/FS.purs
@@ -7,13 +7,14 @@ import Chanterelle.Internal.Types.Compile (CompileError(..))
 import Chanterelle.Internal.Utils.Error (catchingAff, withExceptT')
 import Control.Monad.Error.Class (class MonadThrow, throwError)
 import Data.DateTime.Instant (fromDateTime, unInstant)
+import Data.Function.Uncurried (runFn2, runFn3)
 import Effect (Effect)
 import Effect.Aff (Milliseconds)
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (liftEffect)
-import Node.Encoding (Encoding(UTF8))
+import Node.Encoding (Encoding(..))
 import Node.FS.Aff as FS
-import Node.FS.Sync as FSSync
+import Node.FS.Internal as FSInternal
 import Node.FS.Stats as Stats
 import Node.Path (FilePath)
 import Node.Path as Path
@@ -80,7 +81,9 @@ readTextFile
   => MonadThrow String m
   => FilePath
   -> m String
-readTextFile filename = catchingAff (liftEffect $ FSSync.readTextFile UTF8 filename)
+readTextFile filename = catchingAff wrapInternalRead
+  where wrapInternalRead = liftEffect <<< FSInternal.mkEffect $ \_ -> runFn2
+          FSInternal.unsafeRequireFS.readFileSync filename { encoding: show UTF8, flag: "rs+" }
 
 writeTextFile
   :: forall m
@@ -89,7 +92,9 @@ writeTextFile
   => FilePath
   -> String
   -> m Unit
-writeTextFile filename contents = catchingAff (liftEffect $ FSSync.writeTextFile UTF8 filename contents)
+writeTextFile filename contents = catchingAff wrapInternalWrite
+  where wrapInternalWrite = liftEffect <<< FSInternal.mkEffect $ \_ -> runFn3
+          FSInternal.unsafeRequireFS.writeFileSync filename contents { encoding: show UTF8, flag: "rs+" }
 
 withTextFile
   :: forall m


### PR DESCRIPTION
Fixes #130 

Modifies `Chanterelle.Internal.Utils.FS` to be more explicit with file flags used for reading and writing. This involved re-wrapping Node.FS a little bit.