### PR TITLE
Simplify takeEvent

### DIFF
--- a/example/spago.dhall
+++ b/example/spago.dhall
@@ -2,7 +2,6 @@
 , dependencies =
   [ "aff"
   , "arrays"
-  , "avar"
   , "chanterelle"
   , "effect"
   , "either"


### PR DESCRIPTION
the version of the function we have now is not concurrent friendly. For example if there are multiple transfers coming out of a block, it grabs the first one (e..g see the way the tests are written). This is almost never what you want, in this version of the function it will match with the transaction that was submitted"